### PR TITLE
Updated the sample to work with the latest version of bot framework and LUIS

### DIFF
--- a/Dashboards/Bot Analytics Instrumented Dashboard.txt
+++ b/Dashboards/Bot Analytics Instrumented Dashboard.txt
@@ -1,0 +1,1207 @@
+return {
+	id: "bot_analytics_inst",
+	name: "Bot Analytics Instrumented Dashboard",
+	icon: "dashboard",
+	url: "bot_analytics_inst",
+	description: "Microsoft Bot Framework based analytics",
+	preview: "/images/bot-instrumented.png",
+	category: "Bots",
+	featured: true,
+	html: `<div>
+      This dashboard is built to view events sent by Microsoft Bot Framework based bot.
+      <br/>
+      <br/>
+      <h2>Getting the data to show</h2>
+      <p>
+        To see all the capabilities of this dashboard, it is recommended to integrate you bot with one of the following:
+        <br/>
+        <a href="https://github.com/Azure/botbuilder-instrumentation" target="_blank">
+          Node.js Telemetry Plugin
+        </a>
+        <br/>
+        <a href="https://github.com/Azure/bot-sample-telemetry" target="_blank">C# Telemetry Plugin</a><br/>
+        This will enable the bot to send additional telemetry information to Application Insights.
+      </p>
+      <br/>
+      <h2>Additional Learnings</h2>
+      <p>
+        This dashboard uses 
+        <a href="https://docs.microsoft.com/en-us/azure/application-insights/app-insights-analytics" target="_blank">
+          Application Insights Analytics
+        </a>.
+        <br/>
+        You can also run queries directly using 
+        <a href="https://dev.applicationinsights.io/apiexplorer/query" target="_blank">API Explorer</a>
+      </p>
+    </div>`,
+	config: {
+		connections: {
+			"application-insights": { appId: "ef62b22b-aa5a-413a-501d-f0b4cb71451f",apiKey: "***********" }
+		},
+		layout: {
+			isDraggable: true,
+			isResizable: true,
+			rowHeight: 30,
+			verticalCompact: false,
+			cols: { lg: 12,md: 10,sm: 6,xs: 4,xxs: 2 },
+			breakpoints: { lg: 1200,md: 996,sm: 768,xs: 480,xxs: 0 }
+		}
+	},
+	dataSources: [
+		{
+			id: "timespan",
+			type: "Constant",
+			params: { values: ["24 hours","1 week","1 month","3 months"],selectedValue: "1 month" },
+			format: "timespan"
+		},
+		{
+			id: "modes",
+			type: "Constant",
+			params: { values: ["messages","users"],selectedValue: "messages" },
+			format: "flags"
+		},
+		{
+			id: "filters",
+			type: "ApplicationInsights/Query",
+			dependencies: { timespan: "timespan",queryTimespan: "timespan:queryTimespan",granularity: "timespan:granularity" },
+			params: {
+				table: "customEvents",
+				queries: {
+					channels: {
+						query: () => `
+              where name == 'MBFEvent.UserMessage' 
+              | extend value=tostring(customDimensions.channel) 
+              | summarize channel_count=count() by value 
+              | order by channel_count`,
+						format: "filter"
+					},
+					intents: {
+						query: () => `
+              extend value=tostring(customDimensions.intent), cslen=customDimensions.callstack_length 
+              | where name=='MBFEvent.Intent' and (cslen == 0 or strlen(cslen) == 0) and strlen(value) > 0 
+              | summarize intent_count=count() by value 
+              | order by intent_count`,
+						format: "filter"
+					}
+				}
+			}
+		},
+		{
+			id: "ai",
+			type: "ApplicationInsights/Query",
+			dependencies: {
+				timespan: "timespan",
+				queryTimespan: "timespan:queryTimespan",
+				granularity: "timespan:granularity",
+				selectedChannels: "filters:channels-values-selected",
+				selectedIntents: "filters:intents-values-selected"
+			},
+			params: {
+				table: "customEvents",
+				queries: {
+					timeline: {
+						query: ({ granularity }) => `
+								where name == 'MBFEvent.UserMessage' 
+                | summarize count=count() by bin(timestamp, ${granularity}), 
+                  name, channel=tostring(customDimensions.channel) 
+								| order by timestamp asc `,
+						filters: [{ dependency: "selectedChannels",queryProperty: "customDimensions.channel" }],
+						format: { type: "timeline",args: { timeField: "timestamp",lineField: "channel",valueField: "count" } }
+					},
+					"users-timeline": {
+						query: ({ granularity }) => `
+                where name == 'MBFEvent.UserMessage' 
+                | summarize count=dcount(tostring(customDimensions.userId)) by bin(timestamp, ${granularity}), 
+                  name, channel=tostring(customDimensions.channel) 
+                | order by timestamp asc`,
+						filters: [{ dependency: "selectedChannels",queryProperty: "customDimensions.channel" }],
+						format: { type: "timeline",args: { timeField: "timestamp",lineField: "channel",valueField: "count" } }
+					},
+					intents: {
+						query: () => `
+              extend cslen=customDimensions.callstack_length, value=tostring(customDimensions.intent) 
+              | where name=='MBFEvent.Intent' and (cslen == 0 or strlen(cslen) == 0) and strlen(value) > 0 
+              | summarize count=count() by value`,
+						filters: [{ dependency: "selectedIntents",queryProperty: "customDimensions.intent" }],
+						format: "bars"
+					},
+					conversions: {
+						query: () => `
+              extend successful=(customDimensions.successful == 'true') 
+              | summarize count_start=countif(name == 'MBFEvent.StartTransaction'), 
+                count_end=countif(name == 'MBFEvent.EndTransaction' and successful) by name, successful 
+              | where name == 'MBFEvent.StartTransaction' or (name == 'MBFEvent.EndTransaction' and successful) 
+              | extend count_start=toreal(count_start), count_end=toreal(count_end) 
+              | summarize count=sum(count_start) * 100 / sum(count_end)`,
+						filters: [{ dependency: "selectedChannels",queryProperty: "customDimensions.channel" }],
+						format: {
+							type: "scorecard",
+							args: { postfix: "%",thresholds: [{ value: 0,color: "#2196F3",icon: "input",heading: "Conversions" }] }
+						}
+					},
+					mapActivity: {
+						query: () => `
+              where name=='MBFEvent.UserMessage' 
+              | extend location=strcat(client_City, ', ', client_CountryOrRegion) 
+              | summarize location_count=count() by location 
+              | extend popup=strcat('<b>', location, '</b><br />', location_count, ' messages') `,
+						filters: [{ dependency: "selectedChannels",queryProperty: "customDimensions.channel" }]
+					},
+					sentiments: {
+						query: () => `
+              where name startswith 'MBFEvent.Sentiment' 
+              | extend score=customDimensions.score
+              | summarize count=100 * avg(todouble(score))`,
+						format: {
+							type: "scorecard",
+							args: {
+								postfix: "%",
+								thresholds: [
+									{ value: 0,color: "#D50000",icon: "sentiment_dissatisfied",heading: "Sentiment" },
+									{ value: 40,color: "#FF9810",icon: "sentiment_neutral",heading: "Sentiment" },
+									{ value: 60,color: "#AEEA00",icon: "sentiment_satisfied",heading: "Sentiment" }
+								],
+								subvalueThresholds: [
+									{ value: 0,subheading: "Negative" },
+									{ value: 40,subheading: "Neutral" },
+									{ value: 60,subheading: "Positive" }
+								]
+							}
+						}
+					},
+					goals: {
+						query: () => `
+              extend GoalName=tostring(customDimensions.GoalName)  
+              | where name=="MBFEvent.GoalEvent" 
+              | summarize count=count() by GoalName 
+              | take 3`,
+						filters: [{ dependency: "selectedChannels",queryProperty: "customDimensions.channel" }],
+						format: { type: "bars",args: { barsField: "GoalName",seriesField: "GoalName" } }
+					}
+				}
+			}
+		},
+		{
+			id: "errors",
+			type: "ApplicationInsights/Query",
+			dependencies: { timespan: "timespan",queryTimespan: "timespan:queryTimespan" },
+			params: { query: () => `exceptions | summarize count=count()` },
+			format: {
+				type: "scorecard",
+				args: {
+					thresholds: [
+						{ value: 0,color: "#AEEA00",heading: "Errors",icon: "done",subheading: "Avg" },
+						{ value: 1,color: "#D50000",heading: "Errors",icon: "bug_report",subheading: "Avg" }
+					]
+				}
+			}
+		},
+		{
+			id: "retention",
+			type: "ApplicationInsights/Query",
+			dependencies: { timespan: "timespan",selectedTimespan: "timespan:queryTimespan",queryTimespan: "::P90D" },
+			params: {
+				query: () => `
+          customEvents 
+          | where name=='MBFEvent.UserMessage' 
+          | extend uniqueUser=tostring(customDimensions.userId) 
+          | summarize oldestVisit=min(timestamp), lastVisit=max(timestamp) by uniqueUser 
+          | summarize
+            totalUnique = dcount(uniqueUser),
+            totalUniqueUsersIn24hr = countif(lastVisit > ago(24hr)),
+            totalUniqueUsersIn7d = countif(lastVisit > ago(7d)),
+            totalUniqueUsersIn30d = countif(lastVisit > ago(30d)),
+            returning24hr = countif(lastVisit > ago(24hr) and oldestVisit <= ago(24hr)),
+            returning7d = countif(lastVisit > ago(7d) and oldestVisit <= ago(7d)),
+            returning30d = countif(lastVisit > ago(30d) and oldestVisit <= ago(30d))`
+			},
+			format: "retention"
+		}
+	],
+	filters: [
+		{
+			type: "TextFilter",
+			title: "Timespan",
+			source: "timespan",
+			actions: { onChange: "timespan:updateSelectedValue" },
+			first: true
+		},
+		{
+			type: "TextFilter",
+			title: "Mode",
+			source: "modes",
+			actions: { onChange: "modes:updateSelectedValue" },
+			first: true
+		},
+		{
+			type: "MenuFilter",
+			title: "Channels",
+			subtitle: "Select channels",
+			source: "filters:channels",
+			actions: { onChange: "filters:updateSelectedValues:channels-values-selected" },
+			first: true
+		},
+		{
+			type: "MenuFilter",
+			title: "Intents",
+			subtitle: "Select intents",
+			source: "filters:intents",
+			actions: { onChange: "filters:updateSelectedValues:intents-values-selected" },
+			first: true
+		}
+	],
+	elements: [
+		{
+			id: "timeline",
+			type: "Timeline",
+			title: "Message Rate",
+			subtitle: "How many messages were sent per timeframe",
+			size: { w: 5,h: 8 },
+			source: "ai:timeline",
+			dependencies: { visible: "modes:messages" }
+		},
+		{
+			id: "timeline",
+			type: "Timeline",
+			title: "Users Rate",
+			subtitle: "How many users were sent per timeframe",
+			size: { w: 5,h: 8 },
+			source: "ai:users-timeline",
+			dependencies: { visible: "modes:users" }
+		},
+		{
+			id: "channels",
+			type: "PieData",
+			title: "Channel Usage",
+			subtitle: "Total messages sent per channel",
+			size: { w: 3,h: 8 },
+			source: "ai:timeline",
+			dependencies: { visible: "modes:messages" },
+			props: { showLegend: true,compact: true,entityType: "Messages" }
+		},
+		{
+			id: "channels",
+			type: "PieData",
+			title: "Channel Usage (Users)",
+			subtitle: "Total users sent per channel",
+			size: { w: 3,h: 8 },
+			source: "ai:users-timeline",
+			dependencies: { visible: "modes:users" },
+			props: { showLegend: true,compact: true,entityType: "Users" }
+		},
+		{
+			id: "scores",
+			type: "Scorecard",
+			size: { w: 4,h: 3 },
+			source: { errors: "errors",sentiment: "ai:sentiments",conversions: "ai:conversions" },
+			dependencies: {
+				card_errors_tooltip: "::Total errors",
+				card_errors_onClick: "::onErrorsClick",
+				card_users_value: "retention:total",
+				card_users_heading: "::Users",
+				card_users_icon: "::account_circle",
+				card_users_subvalue: "retention:returning",
+				card_users_subheading: "::Returning",
+				card_users_tooltip: "::Total users and retention",
+				card_users_onClick: "::onUsersClick",
+				card_sentiment_tooltip: "::Average sentiment",
+				card_sentiment_onClick: "::onSentimentsClick",
+				card_conversions_tooltip: "::Percentage of user interactions completed with a conversion"
+			},
+			actions: {
+				onErrorsClick: {
+					action: "dialog:errors",
+					params: {
+						title: "args:heading",
+						type: "args:type",
+						innermostMessage: "args:innermostMessage",
+						queryspan: "timespan:queryTimespan"
+					}
+				},
+				onUsersClick: { action: "dialog:userRetention",params: { title: "args:heading",queryspan: "::P90D" } },
+				onSentimentsClick: {
+					action: "dialog:sentimentConversations",
+					params: { title: "args:heading",queryspan: "timespan:queryTimespan" }
+				}
+			}
+		},
+		{
+			id: "intents",
+			type: "BarData",
+			title: "Intents Graph",
+			subtitle: "Intents usage per time",
+			size: { w: 4,h: 8 },
+			source: "ai:intents",
+			actions: {
+				onBarClick: {
+					action: "dialog:intentsDialog",
+					params: { title: "args:value",intent: "args:value",queryspan: "timespan:queryTimespan" }
+				}
+			}
+		},
+		{
+			id: "timeline-area",
+			type: "Area",
+			title: "Message Rate",
+			subtitle: "How many messages were sent per timeframe",
+			size: { w: 4,h: 8 },
+			source: "ai:timeline",
+			props: { isStacked: true,showLegend: false }
+		},
+		{
+			id: "map",
+			type: "MapData",
+			title: "Map Activity",
+			subtitle: "Monitor regional activity",
+			size: { w: 4,h: 13 },
+			location: { x: 9,y: 1 },
+			source: "ai:mapActivity",
+			props: { mapProps: { zoom: 1,maxZoom: 6 },searchLocations: true }
+		},
+		{
+			id: "goals",
+			type: "BarData",
+			title: "Goals Graph",
+			subtitle: "Goals triggered per time",
+			size: { w: 8,h: 8 },
+			source: "ai:goals",
+			props: { nameKey: "GoalName" },
+			actions: {
+				onBarClick: {
+					action: "dialog:goalsTriggeredDialog",
+					params: { queryspan: "timespan:queryTimespan",selectedChannels: "filters:channels-values-selected" }
+				}
+			}
+		}
+	],
+	dialogs: [
+		{
+			id: "intentsDialog",
+			width: "70%",
+			params: ["title","intent","queryspan"],
+			dataSources: [
+				{
+					id: "intents-data",
+					type: "ApplicationInsights/Query",
+					dependencies: {
+						intent: "dialog_intentsDialog:intent",
+						queryTimespan: "dialog_intentsDialog:queryspan",
+						timespan: "timespan",
+						granularity: "timespan:granularity"
+					},
+					params: {
+						table: "customEvents",
+						queries: {
+							"intent-usage-timeline": {
+								query: ({ intent, granularity }) => `
+                  extend intent=(customDimensions.intent)
+                  | where timestamp > ago(30d) and intent =~ '${intent}'
+                  | summarize count=count() by bin(timestamp, ${granularity})
+                  | order by timestamp`,
+								format: { type: "timeline",args: { timeField: "timestamp",lineField: "intent",valueField: "count" } }
+							},
+							"entities-usage": {
+								query: ({ intent }) => `
+                  extend conversation=tostring(customDimensions.conversationId), 
+                    entityType=tostring(customDimensions.entityType), 
+                    entityValue=tostring(customDimensions.entityValue), 
+                    intent=customDimensions.intent 
+                  | where name=='MBFEvent.Entity' and intent =~'${intent}' 
+                  | project conversation, entityType, entityValue, intent 
+                  | summarize count=count() by entityType, entityValue`,
+								format: {
+									type: "bars",
+									args: { barsField: "entityType",seriesField: "entityValue",valueField: "count",threshold: 10 }
+								}
+							},
+							"total-conversations": {
+								query: ({ intent }) => `
+                  extend conversation=tostring(customDimensions.conversationId), intent=customDimensions.intent 
+                  | where name=='MBFEvent.Intent' and intent =~ '${intent}' 
+                  | summarize count_intents=count() by conversation  
+                  | count`,
+								format: {
+									type: "scorecard",
+									args: {
+										countField: "Count",
+										thresholds: [{ value: 0,color: "#2196F3",icon: "chat",heading: "Conversations" }]
+									}
+								}
+							},
+							"intent-utterances": {
+								query: ({ intent }) => `
+                  extend conversation=tostring(customDimensions.conversationId), 
+                    intent=customDimensions.intent,
+                    text=substring(customDimensions.text, 0, 50) 
+                  | where name=='MBFEvent.Intent' and intent =~ '${intent}' 
+                  | summarize count_utterances=count(), maxTimestamp=max(timestamp) by text 
+                  | order by count_utterances 
+                  | top 5 by count_utterances `
+							}
+						}
+					}
+				},
+				{
+					id: "intentSentiments",
+					type: "ApplicationInsights/Query",
+					dependencies: { intent: "dialog_intentsDialog:intent",queryTimespan: "dialog_intentsDialog:queryspan" },
+					params: {
+						query: ({ intent }) => `
+              customEvents 
+              | extend intent=customDimensions.intent 
+              | where name startswith 'MBFEvent.Intent' and intent =~ '${intent}' 
+              | extend timestamp=tostring(customDimensions.timestamp),
+                conversation=tostring(customDimensions.conversationId),
+                userId=tostring(customDimensions.userId) 
+              | join kind= leftouter (
+                customEvents 
+                | where name startswith 'MBFEvent.Sentiment' 
+                | extend timestamp=tostring(customDimensions.timestamp), 
+                  sentiment=todouble(customDimensions.score),
+                  conversation=tostring(customDimensions.conversationId),
+                  userId=tostring(customDimensions.userId)
+              ) on timestamp, userId, conversation 
+              | summarize count=avg(sentiment)
+            `
+					},
+					format: {
+						type: "scorecard",
+						args: {
+							thresholds: [
+								{ value: 0,color: "#D50000",icon: "sentiment_dissatisfied",heading: "Sentiment" },
+								{ value: 40,color: "#FF9810",icon: "sentiment_neutral",heading: "Sentiment" },
+								{ value: 60,color: "#AEEA00",icon: "sentiment_satisfied",heading: "Sentiment" }
+							],
+							subvalueThresholds: [
+								{ value: 0,subheading: "Negative" },
+								{ value: 40,subheading: "Neutral" },
+								{ value: 60,subheading: "Positive" }
+							]
+						}
+					}
+				}
+			],
+			elements: [
+				{
+					id: "entity-usage",
+					type: "BarData",
+					title: "Entity count appearances in intent",
+					subtitle: "Entity usage and count for the selected intent",
+					size: { w: 6,h: 8 },
+					source: "intents-data:entities-usage"
+				},
+				{
+					id: "utterances",
+					type: "Table",
+					size: { w: 4,h: 8 },
+					dependencies: { values: "intents-data:intent-utterances" },
+					props: {
+						cols: [
+							{ header: "Top Utterances",width: "200px",field: "text" },
+							{ header: "Count",field: "count_utterances",type: "number" }
+						]
+					}
+				},
+				{
+					id: "intent-timeline",
+					type: "Timeline",
+					title: "Message Rate",
+					subtitle: "How many messages were sent per timeframe",
+					size: { w: 8,h: 8 },
+					source: "intents-data:intent-usage-timeline"
+				},
+				{
+					id: "conversations-count",
+					type: "Scorecard",
+					size: { w: 2,h: 8 },
+					source: { conversations: "intents-data:total-conversations",sentiment: "intentSentiments" },
+					dependencies: { card_conversations_onClick: "::onConversationsClick" },
+					actions: {
+						onConversationsClick: {
+							action: "dialog:intentConversations",
+							params: {
+								title: "dialog_intentsDialog:title",
+								intent: "dialog_intentsDialog:intent",
+								queryspan: "dialog_intentsDialog:queryspan"
+							}
+						}
+					}
+				}
+			]
+		},
+		{
+			id: "intentConversations",
+			width: "60%",
+			params: ["title","intent","queryspan"],
+			dataSources: [
+				{
+					id: "conversations-data",
+					type: "ApplicationInsights/Query",
+					dependencies: {
+						intent: "dialog_intentConversations:intent",
+						queryTimespan: "dialog_intentConversations:queryspan"
+					},
+					params: {
+						query: ({ intent }) => ` 
+              customEvents
+              | extend conversation=tostring(customDimensions.conversationId), intent=customDimensions.intent
+              | where name=='MBFEvent.Intent' and intent =~ '${intent}'
+              | summarize count=count(), maxTimestamp=max(timestamp) by conversation
+              | order by maxTimestamp`,
+						mappings: { id: (val, row, idx) => `Conversation ${idx}` }
+					}
+				}
+			],
+			elements: [
+				{
+					id: "conversations-list",
+					type: "Table",
+					title: "Conversations",
+					size: { w: 12,h: 16 },
+					dependencies: { values: "conversations-data" },
+					props: {
+						cols: [
+							{ header: "Conversation Id",field: "id" },
+							{ header: "Last Message",field: "maxTimestamp",type: "time",format: "MMM-DD HH:mm:ss" },
+							{ header: "Count",field: "count" },
+							{ type: "button",value: "chat",click: "openMessagesDialog" }
+						]
+					},
+					actions: {
+						openMessagesDialog: {
+							action: "dialog:messages",
+							params: {
+								title: "args:id",
+								conversation: "args:conversation",
+								intent: "dialog_intentConversations:intent",
+								queryspan: "timespan:queryTimespan"
+							}
+						}
+					}
+				}
+			]
+		},
+		{
+			id: "sentimentConversations",
+			width: "60%",
+			params: ["title","queryspan"],
+			dataSources: [
+				{
+					id: "sentiment-conversations-data",
+					type: "ApplicationInsights/Query",
+					dependencies: { queryTimespan: "dialog_sentimentConversations:queryspan" },
+					params: {
+						query: () => ` 
+              customEvents
+              | extend conversation=tostring(customDimensions.conversationId), 
+                intent=customDimensions.intent,
+                timestamp=tostring(customDimensions.timestamp),
+                userId=tostring(customDimensions.userId)
+              | where name=='MBFEvent.Intent'
+              | join kind=leftouter (
+                customEvents 
+                | where name startswith 'MBFEvent.Sentiment' 
+                | extend timestamp=tostring(customDimensions.timestamp), 
+                  sentiment=todouble(customDimensions.score),
+                  conversation=tostring(customDimensions.conversationId),
+                  userId=tostring(customDimensions.userId)
+              ) on timestamp, userId, conversation
+              | summarize count=count(), sentiment=avg(sentiment), maxTimestamp=max(timestamp) by conversation
+              | extend color=iff(sentiment > 0.6, 'green', iff(sentiment < 0.4, 'red', 'yellow')), 
+                icon=iff(sentiment > 0.6, 'sentiment_satisfied', 
+                iff(sentiment < 0.4, 'sentiment_dissatisfied', 'sentiment_neutral'))
+              | order by sentiment`,
+						mappings: { id: (val, row, idx) => `Conversation ${idx}` }
+					},
+					calculated: ({ values }) => {
+            return {
+              top5Positive: _.take(values, 5),
+              top5Negative: _.takeRight(values, 5)
+            };
+          }
+				}
+			],
+			elements: [
+				{
+					id: "top5positive",
+					type: "Table",
+					size: { w: 5,h: 8 },
+					dependencies: { values: "sentiment-conversations-data:top5Positive" },
+					props: {
+						compact: true,
+						cols: [
+							{ header: "Top 5 Positive",field: "id" },
+							{ header: null,width: "10px",field: "icon",type: "icon",color: "color" },
+							{ header: "Last Message",field: "maxTimestamp",type: "time",format: "MMM-DD HH:mm:ss" },
+							{ header: "Count",width: "10px",field: "count" },
+							{ type: "button",width: "10px",value: "chat",click: "openMessagesDialog" }
+						]
+					},
+					actions: {
+						openMessagesDialog: {
+							action: "dialog:messages",
+							params: {
+								title: "args:id",
+								conversation: "args:conversation",
+								queryspan: "timespan:queryTimespan",
+								intent: "::"
+							}
+						}
+					}
+				},
+				{
+					id: "top5negative",
+					type: "Table",
+					size: { w: 5,h: 8 },
+					dependencies: { values: "sentiment-conversations-data:top5Negative" },
+					props: {
+						compact: true,
+						cols: [
+							{ header: "Top 5 Negative",field: "id" },
+							{ header: null,width: "10px",field: "icon",type: "icon",color: "color" },
+							{ header: "Last Message",field: "maxTimestamp",type: "time",format: "MMM-DD HH:mm:ss" },
+							{ header: "Count",field: "count" },
+							{ type: "button",value: "chat",click: "openMessagesDialog" }
+						]
+					},
+					actions: {
+						openMessagesDialog: {
+							action: "dialog:messages",
+							params: {
+								title: "args:id",
+								conversation: "args:conversation",
+								queryspan: "timespan:queryTimespan",
+								intent: "::"
+							}
+						}
+					}
+				}
+			]
+		},
+		{
+			id: "messages",
+			width: "50%",
+			params: ["title","conversation","intent","queryspan"],
+			dataSources: [
+				{
+					id: "messages-data",
+					type: "ApplicationInsights/Query",
+					dependencies: {
+						conversation: "dialog_messages:conversation",
+						optional_intent: "dialog_messages:intent",
+						queryTimespan: "dialog_messages:queryspan"
+					},
+					params: {
+						query: ({ conversation, optional_intent }) => ` 
+              customEvents
+              | extend intent=tostring(customDimensions.intent), 
+                conversation=tostring(customDimensions.conversationId), 
+                eventTimestamp=tostring(customDimensions.timestamp),
+                userId=tostring(customDimensions.userId)
+              | where name == 'MBFEvent.UserMessage' and conversation == '${conversation}'
+              | join kind= leftouter (
+                customEvents
+                | extend sentiment=tostring(customDimensions.score),
+                  eventTimestamp=tostring(customDimensions.timestamp), 
+                  conversation=tostring(customDimensions.conversationId),
+                  userId=tostring(customDimensions.userId)
+                | where name == 'MBFEvent.Sentiment' and conversation == '${conversation}'
+              ) on eventTimestamp, conversation, userId
+              ${optional_intent && `
+                | union (
+                  customEvents
+                  | extend conversation=tostring(customDimensions.conversationId), 
+                    intent=tostring(customDimensions.intent),
+                    eventTimestamp=tostring(customDimensions.timestamp),
+                    userId=tostring(customDimensions.userId)
+                  | where name == 'MBFEvent.Intent' 
+                    and intent == '${optional_intent}' and conversation == '${conversation}'
+                )
+              ` || ''}
+              | union (
+                customEvents
+                | extend conversation=tostring(customDimensions.conversationId), 
+                  intent=tostring(customDimensions.intent), 
+                  eventTimestamp=tostring(customDimensions.timestamp),
+                  userId=tostring(customDimensions.userId)
+                | where name == 'MBFEvent.BotMessage' and conversation == '${conversation}'
+              )
+              | project timestamp, eventName=name, message=customDimensions.text, 
+                customDimensions.userName, userId, intent, sentiment
+              | order by timestamp asc
+              `
+					},
+					calculated: (state, dependencies) => {
+            let { values } = state;
+
+            if (!values) { return; }
+
+            _.forEach(values, (msg, index) => {
+              msg.message = msg.message;
+              msg.icon = isNaN(parseInt(msg.sentiment, 10)) ? '' :
+                msg.sentiment > 0.6 ? 'sentiment_satisfied' :
+                  msg.sentiment < 0.4 ? 'sentiment_dissatisfied' : '';
+              msg.color = isNaN(parseInt(msg.sentiment, 10)) ? '' :
+                msg.sentiment > 0.6 ? '#AEEA00' :
+                  msg.sentiment < 0.4 ? '#D50000' : '';
+
+              if (msg.eventName === 'MBFEvent.UserMessage') {
+                let i = +index;
+                let j = i + 1;
+                while (j <= i + 5 && j < values.length) {
+                  let intent = values[j];
+                  if (intent.eventName === 'MBFEvent.Intent' && intent.message === msg.message && intent.intent) {
+                    msg.intent = intent.intent;
+                    msg.message = '[' + msg.intent + '] ' + msg.message;
+                    msg.eventName = msg.eventName + ' intent';
+                    break;
+                  }
+                  j++;
+                }
+              }
+            });
+
+            let chat = values.filter(msg => msg.eventName !== 'MBFEvent.Intent');
+
+            return { chat };
+          }
+				}
+			],
+			elements: [
+				{
+					id: "messages-list",
+					type: "Table",
+					title: "Messages",
+					size: { w: 12,h: 16 },
+					dependencies: { values: "messages-data:chat" },
+					props: {
+						rowClassNameField: "eventName",
+						cols: [
+							{ header: "Timestamp",width: "50px",field: "timestamp",type: "time",format: "MMM-DD HH:mm:ss" },
+							{ width: "10px",field: "icon",type: "icon",color: "color" },
+							{ header: "Message",width: "500px",field: "message" }
+						]
+					}
+				}
+			]
+		},
+		{
+			id: "errors",
+			width: "90%",
+			params: ["title","queryspan"],
+			dataSources: [
+				{
+					id: "errors-group",
+					type: "ApplicationInsights/Query",
+					dependencies: { queryTimespan: "dialog_errors:queryspan" },
+					params: {
+						query: () => ` 
+              exceptions
+              | summarize error_count=count() by type, innermostMessage
+              | project type, innermostMessage, error_count
+              | order by error_count desc `
+					}
+				},
+				{
+					id: "errors-selection",
+					type: "ApplicationInsights/Query",
+					dependencies: {
+						queryTimespan: "dialog_errors:queryspan",
+						type: "args:type",
+						innermostMessage: "args:innermostMessage"
+					},
+					params: {
+						query: ({ type, innermostMessage }) => `
+              exceptions
+              | where type == "${type}" 
+              | where innermostMessage == "${innermostMessage}" 
+              | extend conversationId=customDimensions['Conversation ID'] 
+              | project type, innermostMessage, handledAt, conversationId, operation_Id `
+					}
+				}
+			],
+			elements: [
+				{
+					id: "errors-list",
+					type: "SplitPanel",
+					title: "Errors",
+					size: { w: 12,h: 16 },
+					dependencies: { groups: "errors-group",values: "errors-selection" },
+					props: {
+						cols: [
+							{ header: "Type",field: "type",secondaryHeader: "Message",secondaryField: "innermostMessage" },
+							{
+								header: "Conversation Id",
+								field: "conversationId",
+								secondaryHeader: "Operation Id",
+								secondaryField: "operation_Id"
+							},
+							{ header: "HandledAt",field: "handledAt" },
+							{ type: "button",value: "more",click: "openErrorDetail" }
+						],
+						group: { field: "type",secondaryField: "innermostMessage",countField: "error_count" }
+					},
+					actions: {
+						select: {
+							action: "errors-selection:updateDependencies",
+							params: {
+								title: "args:type",
+								type: "args:type",
+								innermostMessage: "args:innermostMessage",
+								queryspan: "timespan:queryTimespan"
+							}
+						},
+						openErrorDetail: {
+							action: "dialog:errordetail",
+							params: {
+								title: "args:operation_Id",
+								type: "args:type",
+								innermostMessage: "args:innermostMessage",
+								handledAt: "args:handledAt",
+								conversationId: "args:conversationId",
+								operation_Id: "args:operation_Id",
+								queryspan: "timespan:queryTimespan"
+							}
+						}
+					}
+				}
+			]
+		},
+		{
+			id: "errordetail",
+			width: "50%",
+			params: ["title","handledAt","type","operation_Id","queryspan"],
+			dataSources: [
+				{
+					id: "errordetail-data",
+					type: "ApplicationInsights/Query",
+					dependencies: { operation_Id: "dialog_errordetail:operation_Id",queryTimespan: "dialog_errordetail:queryspan" },
+					params: {
+						query: ({ operation_Id }) => ` 
+              exceptions
+              | where operation_Id == '${operation_Id}'
+              | extend conversationId=customDimensions['Conversation ID']
+              | project handledAt, type, innermostMessage, conversationId, operation_Id, timestamp, details `
+					}
+				}
+			],
+			elements: [
+				{
+					id: "errordetail-item",
+					type: "Detail",
+					title: "Error detail",
+					size: { w: 12,h: 16 },
+					dependencies: { values: "errordetail-data" },
+					props: {
+						cols: [
+							{ header: "Handle",field: "handledAt" },
+							{ header: "Type",field: "type" },
+							{ header: "Message",field: "innermostMessage" },
+							{ header: "Conversation ID",field: "conversationId" },
+							{ header: "Operation ID",field: "operation_Id" },
+							{ header: "Timestamp",field: "timestamp" },
+							{ header: "Details",field: "details" }
+						]
+					}
+				}
+			]
+		},
+		{
+			id: "userRetention",
+			width: "50%",
+			params: ["title","queryspan"],
+			dataSources: [
+				{
+					id: "ai-ur",
+					type: "ApplicationInsights/Query",
+					dependencies: {
+						timespan: "timespan",
+						queryTimespan: "timespan:queryTimespan",
+						granularity: "timespan:granularity",
+						selectedChannels: "filters:channels-values-selected",
+						selectedIntents: "filters:intents-values-selected"
+					},
+					params: {
+						table: "customEvents",
+						queries: {
+							retention_total_incoming_messages: {
+								query: () => `where name == 'MBFEvent.UserMessage' | count`,
+								filters: [{ dependency: "selectedChannels",queryProperty: "customDimensions.channel" }],
+								format: { type: "scorecard",args: { countField: "Count" } }
+							},
+							retention_avg_incoming_per_user: {
+								query: () => `
+                  where name == 'MBFEvent.UserMessage' 
+                  | extend userId=tostring(customDimensions.userId) 
+                  | summarize messages=count() by userId 
+                  | summarize count=avg(messages) `,
+								filters: [{ dependency: "selectedChannels",queryProperty: "customDimensions.channel" }],
+								format: { type: "scorecard" }
+							},
+							retention_total_outgoing_messages: {
+								query: () => `where name == 'MBFEvent.BotMessage' | count`,
+								filters: [{ dependency: "selectedChannels",queryProperty: "customDimensions.channel" }],
+								format: { type: "scorecard",args: { countField: "Count" } }
+							},
+							retention_avg_outgoing_per_user: {
+								query: () => `
+                  where name == 'MBFEvent.BotMessage' 
+                  | extend userId=tostring(customDimensions.userId), 
+                    conversation=tostring(customDimensions.conversationId) 
+                  | summarize messages=count() by userId, conversation 
+                  | summarize count=avg(messages) `,
+								filters: [{ dependency: "selectedChannels",queryProperty: "customDimensions.channel" }],
+								format: { type: "scorecard" }
+							},
+							retention_avg_sessions_per_user: {
+								query: () => `
+                  where name == 'MBFEvent.UserMessage' 
+                  | extend userId=tostring(customDimensions.userId), 
+                    conversation=tostring(customDimensions.conversationId) 
+                  | summarize messages=count() by bin(timestamp, 1h), conversation, userId 
+                  | summarize sum_sessions=count() by conversation, userId 
+                  | summarize count=avg(sum_sessions)`,
+								filters: [{ dependency: "selectedChannels",queryProperty: "customDimensions.channel" }],
+								format: { type: "scorecard" }
+							},
+							retention_avg_messages_per_session: {
+								query: () => `
+                  where name == 'MBFEvent.UserMessage' 
+                  | extend userId=tostring(customDimensions.userId), 
+                    conversation=tostring(customDimensions.conversationId) 
+                  | summarize messages=count() by bin(timestamp, 1h), conversation, userId 
+                  | summarize sum_sessions=count() by conversation, userId 
+                  | summarize count=avg(sum_sessions)`,
+								filters: [{ dependency: "selectedChannels",queryProperty: "customDimensions.channel" }],
+								format: { type: "scorecard" }
+							},
+							retention_top_users: {
+								query: () => `
+                  where name == 'MBFEvent.UserMessage' 
+                  | extend userId=substring(tostring(customDimensions.userId), 0, 30), 
+                    fullUserId=tostring(customDimensions.userId) 
+                  | summarize messages=count() by fullUserId, userId 
+                  | top 5 by messages 
+                `,
+								filters: [{ dependency: "selectedChannels",queryProperty: "customDimensions.channel" }]
+							}
+						}
+					}
+				}
+			],
+			elements: [
+				{
+					id: "retention-scores",
+					type: "Scorecard",
+					size: { w: 6,h: 3 },
+					dependencies: {
+						card_msgs_icon: "::chat",
+						card_msgs_value: "ai-ur:retention_total_incoming_messages-value",
+						card_msgs_heading: "::Total Msgs",
+						card_msgs_subvalue: "ai-ur:retention_total_outgoing_messages-value",
+						card_msgs_subheading: "::Outgoing",
+						card_msgs_color: "::#2196F3",
+						card_impu_icon: "::account_circle",
+						card_impu_value: "ai-ur:retention_avg_incoming_per_user-value",
+						card_impu_heading: "::Avg msg/usr",
+						card_impu_subvalue: "ai-ur:retention_avg_outgoing_per_user-value",
+						card_impu_subheading: "::Outgoing",
+						card_impu_color: "::#2196F3",
+						card_aspu_icon: "::account_circle",
+						card_aspu_value: "ai-ur:retention_avg_sessions_per_user-value",
+						card_aspu_heading: "::Avg ssn/usr",
+						card_aspu_subvalue: "ai-ur:retention_avg_messages_per_session-value",
+						card_aspu_subheading: "::Msg/Session",
+						card_aspu_color: "::#2196F3"
+					}
+				},
+				{
+					id: "user-retention-table",
+					type: "Table",
+					title: "User Retention",
+					size: { w: 3,h: 9 },
+					dependencies: { values: "retention" },
+					props: {
+						compact: true,
+						cols: [
+							{ header: "Time Span",field: "timespan" },
+							{ header: "Retention",field: "retention" },
+							{ header: "Returning",field: "returning" },
+							{ header: "Unique Users",field: "unique" }
+						]
+					}
+				},
+				{
+					id: "top-users-table",
+					type: "Table",
+					title: "Top Users",
+					size: { w: 3,h: 9 },
+					dependencies: { values: "ai-ur:retention_top_users" },
+					props: {
+						compact: true,
+						cols: [
+							{ header: "User Id",field: "userId" },
+							{ header: "Messages",field: "messages" },
+							{ type: "button",value: "chat",click: "openMessagesDialog" }
+						]
+					},
+					actions: {
+						openMessagesDialog: {
+							action: "dialog:userConversations",
+							params: { title: "args:userId",userId: "args:fullUserId",queryspan: "timespan:queryTimespan" }
+						}
+					}
+				}
+			]
+		},
+		{
+			id: "userConversations",
+			width: "60%",
+			params: ["title","userId","queryspan"],
+			dataSources: [
+				{
+					id: "user-conversations-data",
+					type: "ApplicationInsights/Query",
+					dependencies: { userId: "dialog_userConversations:userId",queryTimespan: "dialog_userConversations:queryspan" },
+					params: {
+						query: ({ userId }) => ` 
+              customEvents
+              | extend conversation=tostring(customDimensions.conversationId), userId=tostring(customDimensions.userId)
+              | where name=='MBFEvent.UserMessage' and userId == '${userId}'
+              | summarize count=count(), maxTimestamp=max(timestamp) by conversation
+              | order by maxTimestamp`,
+						mappings: { id: (val, row, idx) => `Conversation ${idx}` }
+					}
+				}
+			],
+			elements: [
+				{
+					id: "user-conversations-list",
+					type: "Table",
+					title: "Conversations",
+					size: { w: 12,h: 16 },
+					dependencies: { values: "user-conversations-data" },
+					props: {
+						cols: [
+							{ header: "Conversation Id",field: "id" },
+							{ header: "Last Message",field: "maxTimestamp",type: "time",format: "MMM-DD HH:mm:ss" },
+							{ header: "Count",field: "count" },
+							{ type: "button",value: "chat",click: "openMessagesDialog" }
+						]
+					},
+					actions: {
+						openMessagesDialog: {
+							action: "dialog:messages",
+							params: {
+								title: "args:id",
+								conversation: "args:conversation",
+								intent: "dialog_intentConversations:intent",
+								queryspan: "timespan:queryTimespan"
+							}
+						}
+					}
+				}
+			]
+		},
+		{
+			id: "goalsTriggeredDialog",
+			width: "60%",
+			params: ["queryspan","selectedChannels"],
+			dataSources: [
+				{
+					id: "goals-data",
+					type: "ApplicationInsights/Query",
+					dependencies: {
+						queryTimespan: "dialog_goalsTriggeredDialog:queryspan",
+						selectedChannels: "dialog_goalsTriggeredDialog:selectedChannels"
+					},
+					params: {
+						filters: [{ dependency: "selectedChannels",queryProperty: "customDimensions.channel" }],
+						query: () => `customEvents 
+              | extend GoalName=tostring(customDimensions.GoalName) 
+              | where name=='MBFEvent.GoalEvent' 
+              | summarize count=count() by GoalName 
+              | order by GoalName asc`
+					}
+				}
+			],
+			elements: [
+				{
+					id: "goals-count-list",
+					type: "Table",
+					title: "Goals Triggered",
+					size: { w: 12,h: 16 },
+					dependencies: { values: "goals-data",selectedChannels: "dialog_goalsTriggeredDialog:selectedChannels" },
+					props: {
+						cols: [
+							{ header: "Goal Name",field: "GoalName" },
+							{ header: "Count",field: "count" },
+							{ type: "button",value: "chat",click: "openConversationsDialog" }
+						]
+					},
+					actions: {
+						openConversationsDialog: {
+							action: "dialog:goalConversations",
+							params: {
+								title: "args:GoalName",
+								goal: "args:GoalName",
+								queryspan: "timespan:queryTimespan",
+								selectedChannels: "filters:channels-values-selected"
+							}
+						}
+					}
+				}
+			]
+		},
+		{
+			id: "goalConversations",
+			width: "60%",
+			params: ["title","goal","queryspan","selectedChannels"],
+			dataSources: [
+				{
+					id: "goal-conversations-data",
+					type: "ApplicationInsights/Query",
+					dependencies: {
+						goal: "dialog_goalConversations:goal",
+						queryTimespan: "dialog_goalConversations:queryspan",
+						selectedChannels: "dialog_goalConversations:selectedChannels"
+					},
+					params: {
+						filters: [{ dependency: "selectedChannels",queryProperty: "customDimensions.channel" }],
+						query: ({ goal }) => ` 
+              customEvents
+              | extend conversation=tostring(customDimensions.conversationId), 
+                goal=tostring(customDimensions.GoalName)
+              | where name=='MBFEvent.GoalEvent' and goal =~ "${goal}"
+              | summarize count=count(), maxTimestamp=max(timestamp) by conversation
+              | order by maxTimestamp`,
+						mappings: { id: (val, row, idx) => `Conversation ${idx}` }
+					}
+				}
+			],
+			elements: [
+				{
+					id: "conversations-list",
+					type: "Table",
+					title: "Conversations",
+					size: { w: 12,h: 16 },
+					dependencies: { values: "goal-conversations-data" },
+					props: {
+						cols: [
+							{ header: "Conversation Id",field: "id" },
+							{ header: "Last Message",field: "maxTimestamp",type: "time",format: "MMM-DD HH:mm:ss" },
+							{ header: "Count",field: "count" },
+							{ type: "button",value: "chat",click: "openMessagesDialog" }
+						]
+					},
+					actions: {
+						openMessagesDialog: {
+							action: "dialog:messages",
+							params: { title: "args:id",conversation: "args:conversation",queryspan: "timespan:queryTimespan" }
+						}
+					}
+				}
+			]
+		}
+	]
+}

--- a/LUIS/UberBot EN.json
+++ b/LUIS/UberBot EN.json
@@ -1,0 +1,149 @@
+{
+  "luis_schema_version": "2.1.0",
+  "versionId": "0.1",
+  "name": "UberBot EN",
+  "desc": "",
+  "culture": "en-us",
+  "intents": [
+    {
+      "name": "feedback"
+    },
+    {
+      "name": "history.goback"
+    },
+    {
+      "name": "history.info"
+    },
+    {
+      "name": "None"
+    }
+  ],
+  "entities": [],
+  "composites": [],
+  "closedLists": [],
+  "bing_entities": [],
+  "model_features": [],
+  "regex_features": [],
+  "utterances": [
+    {
+      "text": "info",
+      "intent": "history.info",
+      "entities": []
+    },
+    {
+      "text": "i need information",
+      "intent": "history.info",
+      "entities": []
+    },
+    {
+      "text": "go back",
+      "intent": "history.goback",
+      "entities": []
+    },
+    {
+      "text": "feedback",
+      "intent": "feedback",
+      "entities": []
+    },
+    {
+      "text": "information",
+      "intent": "history.info",
+      "entities": []
+    },
+    {
+      "text": "i need feedback",
+      "intent": "feedback",
+      "entities": []
+    },
+    {
+      "text": "give me some feedback",
+      "intent": "feedback",
+      "entities": []
+    },
+    {
+      "text": "can you give me some feedback please?",
+      "intent": "feedback",
+      "entities": []
+    },
+    {
+      "text": "feedback required",
+      "intent": "feedback",
+      "entities": []
+    },
+    {
+      "text": "history info",
+      "intent": "history.info",
+      "entities": []
+    },
+    {
+      "text": "history information",
+      "intent": "history.info",
+      "entities": []
+    },
+    {
+      "text": "information history",
+      "intent": "history.info",
+      "entities": []
+    },
+    {
+      "text": "give me information",
+      "intent": "history.info",
+      "entities": []
+    },
+    {
+      "text": "i need info",
+      "intent": "history.info",
+      "entities": []
+    },
+    {
+      "text": "go back in time",
+      "intent": "history.goback",
+      "entities": []
+    },
+    {
+      "text": "go back in history",
+      "intent": "history.goback",
+      "entities": []
+    },
+    {
+      "text": "let's travel back in time",
+      "intent": "history.goback",
+      "entities": []
+    },
+    {
+      "text": "go back a few years",
+      "intent": "history.goback",
+      "entities": []
+    },
+    {
+      "text": "please go back",
+      "intent": "history.goback",
+      "entities": []
+    },
+    {
+      "text": "let's remember",
+      "intent": "history.goback",
+      "entities": []
+    },
+    {
+      "text": "i want some information",
+      "intent": "history.info",
+      "entities": []
+    },
+    {
+      "text": "tell me something about history",
+      "intent": "history.info",
+      "entities": []
+    },
+    {
+      "text": "i love feedback!",
+      "intent": "feedback",
+      "entities": []
+    },
+    {
+      "text": "tell me about history",
+      "intent": "history.info",
+      "entities": []
+    }
+  ]
+}

--- a/LUIS/UberBot ES.json
+++ b/LUIS/UberBot ES.json
@@ -1,0 +1,184 @@
+{
+  "luis_schema_version": "2.1.0",
+  "versionId": "0.1",
+  "name": "UberBot ES",
+  "desc": "",
+  "culture": "es-es",
+  "intents": [
+    {
+      "name": "feedback"
+    },
+    {
+      "name": "history.goback"
+    },
+    {
+      "name": "history.info"
+    },
+    {
+      "name": "None"
+    }
+  ],
+  "entities": [],
+  "composites": [],
+  "closedLists": [],
+  "bing_entities": [],
+  "model_features": [],
+  "regex_features": [],
+  "utterances": [
+    {
+      "text": "dame información",
+      "intent": "history.info",
+      "entities": []
+    },
+    {
+      "text": "opinión",
+      "intent": "feedback",
+      "entities": []
+    },
+    {
+      "text": "dame tu opinión",
+      "intent": "feedback",
+      "entities": []
+    },
+    {
+      "text": "necesito saber tu opinión",
+      "intent": "feedback",
+      "entities": []
+    },
+    {
+      "text": "comentarios",
+      "intent": "feedback",
+      "entities": []
+    },
+    {
+      "text": "dame comentarios",
+      "intent": "feedback",
+      "entities": []
+    },
+    {
+      "text": "dime comentarios",
+      "intent": "feedback",
+      "entities": []
+    },
+    {
+      "text": "dime tus comentarios",
+      "intent": "feedback",
+      "entities": []
+    },
+    {
+      "text": "dime tu opinión",
+      "intent": "feedback",
+      "entities": []
+    },
+    {
+      "text": "necesito tus comentarios",
+      "intent": "feedback",
+      "entities": []
+    },
+    {
+      "text": "coméntame",
+      "intent": "feedback",
+      "entities": []
+    },
+    {
+      "text": "información",
+      "intent": "history.info",
+      "entities": []
+    },
+    {
+      "text": "infórmame",
+      "intent": "history.info",
+      "entities": []
+    },
+    {
+      "text": "necesito info",
+      "intent": "history.info",
+      "entities": []
+    },
+    {
+      "text": "necesito información",
+      "intent": "history.info",
+      "entities": []
+    },
+    {
+      "text": "puedes darme información?",
+      "intent": "history.info",
+      "entities": []
+    },
+    {
+      "text": "que info puedes compartir conmigo?",
+      "intent": "history.info",
+      "entities": []
+    },
+    {
+      "text": "vamos hacia detrás en el tiempo",
+      "intent": "history.goback",
+      "entities": []
+    },
+    {
+      "text": "viajemos un poco en el tiempo",
+      "intent": "history.goback",
+      "entities": []
+    },
+    {
+      "text": "viajemos en el tiempo",
+      "intent": "history.goback",
+      "entities": []
+    },
+    {
+      "text": "vayamos atrás en el tiempo",
+      "intent": "history.goback",
+      "entities": []
+    },
+    {
+      "text": "vayamos atrás",
+      "intent": "history.goback",
+      "entities": []
+    },
+    {
+      "text": "un poco más atrás",
+      "intent": "history.goback",
+      "entities": []
+    },
+    {
+      "text": "dime algo del pasado",
+      "intent": "history.goback",
+      "entities": []
+    },
+    {
+      "text": "retroalimentación",
+      "intent": "feedback",
+      "entities": []
+    },
+    {
+      "text": "retroalimentar",
+      "intent": "feedback",
+      "entities": []
+    },
+    {
+      "text": "cuéntame sobre la historia",
+      "intent": "history.info",
+      "entities": []
+    },
+    {
+      "text": "cuéntame algo sobre historia",
+      "intent": "history.info",
+      "entities": []
+    },
+    {
+      "text": "historia",
+      "intent": "history.info",
+      "entities": []
+    },
+    {
+      "text": "dame información sobre historia",
+      "intent": "history.info",
+      "entities": []
+    },
+    {
+      "text": "vuelve a 2001",
+      "intent": "history.goback",
+      "entities": []
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ and change:
 
 ```json
 {
-  "BOT_MicrosoftAppId": "<GUID for registered bot id>",
-  "BOT_MicrosoftAppPassword": "<Password for registered bot>",
-  "LUIS_modelBaseURL":"https://api.projectoxford.ai/luis/v1/application",
+  "MicrosoftAppId": "<GUID for registered bot id>",
+  "MicrosoftAppPassword": "<Password for registered bot>",
+  "COSMOSDB_host": "<Replace with the Url for your own CosmosDB>",
+  "COSMOSDB_key": "<Replace with a key for your own CosmosDB>",
+  "LUIS_modelBaseURL":"https://westeurope.api.cognitive.microsoft.com/luis/v2.0/apps",
   "LUIS_applicationId_en":"<You can use as is or replace with a LUIS app id for your own english model>",
   "LUIS_applicationId_es":"<You can use as is or replace with a LUIS app id for your own spanish model>",
   "LUIS_subscriptionKey":"<You can use as is or replace with your own LUIS subscription id>"

--- a/app.js
+++ b/app.js
@@ -1,7 +1,9 @@
 var restify = require('restify');
 var builder = require('botbuilder');
-var uberBot = require('./uber-bot');
+var azure = require('botbuilder-azure');
+var instrumentation = require('botbuilder-instrumentation');
 
+var uberBot = require('./uber-bot');
 var config = require('./config');
 
 //=========================================================
@@ -16,11 +18,29 @@ server.listen(process.env.port || process.env.PORT || 3978, function () {
     console.log('%s listening to %s', server.name, server.url);
 });
 
+// Configure custom state data storage
+var cosmosDbOptions = {
+    host: config.get('COSMOSDB_host'),
+    masterKey: config.get('COSMOSDB_key'), 
+    database: 'botdocs',   
+    collection: 'botdata'
+};
+var cosmosDbClient = new azure.DocumentDbClient(cosmosDbOptions);
+var cosmosStorage = new azure.AzureBotStorage({ gzipData: false }, cosmosDbClient);
+
+// Configure instrumentation
+var logging = new instrumentation.BotFrameworkInstrumentation({
+    instrumentationKey: config.get('BotDevAppInsightsKey'),
+    sentiments: {
+        key: config.get('SENTIMENT_subscriptionkey')
+    }
+});
+
 // Create chat bot
 var connector = new builder.ChatConnector({
-    appId: config.get('BOT_MicrosoftAppId'),
-    appPassword: config.get('BOT_MicrosoftAppPassword')
+    appId: config.get('MicrosoftAppId'),
+    appPassword: config.get('MicrosoftAppPassword')
 });
-uberBot.create(connector);
+uberBot.create(connector, cosmosStorage, logging);
 
 server.post('/api/messages', connector.listen());

--- a/bots/feedback/index.js
+++ b/bots/feedback/index.js
@@ -14,13 +14,13 @@ var feedbackBot = (function () {
   _lib.localePath('./bots/feedback/locale/');
   _lib.dialog('/', [
       function (session, results, next) {
-          session.endDialog("feedback-welcome");
+          session.endDialog("welcome");
       }
   ]);
 
   _lib.dialog('feedback', [
       function (session, results) {
-          session.endDialog('feedback-message');
+          session.endDialog('message');
       }
   ]);
 
@@ -29,23 +29,27 @@ var feedbackBot = (function () {
   }
 
   function getName (session) { 
-    return session.localizer.gettext(session.preferredLocale(), "feedback-name");
+    return session.localizer.gettext(session.preferredLocale(), "name", _lib.name);
   }
 
   function welcomeMessage (session) {
-      return session.localizer.gettext(session.preferredLocale(), "feedback-welcome");
+      return session.localizer.gettext(session.preferredLocale(), "welcome", _lib.name);
   }
 
   function initialize (locale) {
 
       // Create LUIS recognizer that points at our model for selected locale
-      model = config.get('LUIS_modelBaseURL')+"?id="+config.get('LUIS_applicationId_' + locale)+"&subscription-key="+config.get('LUIS_subscriptionKey')+"&q=";
+      model = config.get('LUIS_modelBaseURL')+"/"+config.get('LUIS_applicationId_' + locale)+"?subscription-key="+config.get('LUIS_subscriptionKey')+"&q=";
       
-      intents = new builder.IntentDialog();
+      var recognizer = new builder.LuisRecognizer(model);
+      intents = new builder.IntentDialog({ recognizers: [recognizer] });
       intents.onDefault("feedbackBot:/");
-      intents.matches(/^(feedback|משוב)/i, "feedbackBot:feedback");
-      // .onDefault(builder.DialogAction.send("I'm sorry. I didn't understand."))
-      return intents;
+      intents.matches('feedback', "feedbackBot:feedback");
+      
+      return {
+        intents: intents,
+        recognizer: recognizer
+      };
   };
 
   return {

--- a/bots/feedback/locale/en/feedbackBot.json
+++ b/bots/feedback/locale/en/feedbackBot.json
@@ -1,0 +1,5 @@
+{
+  "name": "Feedback",
+  "welcome": "I am the Feedback Bot! \n\n Type 'feedback' for more info",
+  "message": "The feedback from this week is: \n\n1. Some placeholder text \n\n2. Some placeholder text \n\n3. Some placeholder text \n\n4. Some placeholder text \n\n5. Some placeholder text \n\n"
+}

--- a/bots/feedback/locale/en/index.json
+++ b/bots/feedback/locale/en/index.json
@@ -1,5 +1,0 @@
-{
-  "feedback-name": "Feedback",
-  "feedback-welcome": "I am the Sage Feedback Bot! \n\n Type 'feedback' for more info",
-  "feedback-message": "The feedback from this week is: \n\n1. Some placeholder text \n\n2. Some placeholder text \n\n3. Some placeholder text \n\n4. Some placeholder text \n\n5. Some placeholder text \n\n"
-}

--- a/bots/feedback/locale/es/feedbackBot.json
+++ b/bots/feedback/locale/es/feedbackBot.json
@@ -1,0 +1,5 @@
+{
+  "name": "Comentarios",
+  "welcome": "¡Bienvenido al bot de Comentarios! Escribe 'Comentarios' para ver los comentarios",
+  "message": "Los comentarios de esta semana son: \n\n1. Un comentario \n\n2. Otro comentario \n\n3. Y otro comentario \n\n4. Y van 4 comentarios \n\n5. Y con este van 5 comentarios \n\n"
+}

--- a/bots/feedback/locale/es/index.json
+++ b/bots/feedback/locale/es/index.json
@@ -1,5 +1,0 @@
-{
-  "feedback-name": "retroalimentación",
-  "feedback-welcome": "la bienvenida a la retroalimentación bot! escribir 'retroalimentación' para dar una retroalimentación",
-  "feedback-message": "retroalimentación de esta semana es: \n\n1. texto texto texto texto \n\n2. texto texto texto texto \n\n3. texto texto texto texto \n\n4. texto texto texto texto \n\n5. texto texto texto texto \n\n"
-}

--- a/bots/history/index.js
+++ b/bots/history/index.js
@@ -5,7 +5,7 @@ var config = require('../../config');
 // Library creation
 //=========================================================
 
-var feedbackBot = (function () {
+var historyBot = (function () {
 
   var model;
   var recognizer;
@@ -14,19 +14,19 @@ var feedbackBot = (function () {
   _lib.localePath('./bots/history/locale/');
   _lib.dialog('/', [
       function (session, results, next) {
-          session.endDialog("history-welcome");
+          session.endDialog("welcome");
       }
   ]);
 
   _lib.dialog('info', [
     function (session, results) {
-        session.endDialog("history-details");
+        session.endDialog("details");
     }
   ]);
 
   _lib.dialog('goback', [
     function (session, results) {
-        session.endDialog("history-goback");
+        session.endDialog("goback");
     }
   ]);
 
@@ -35,17 +35,17 @@ var feedbackBot = (function () {
   }
 
   function getName (session) { 
-    return session.localizer.gettext(session.preferredLocale(), "history-name");
+    return session.localizer.gettext(session.preferredLocale(), "name", _lib.name);
   }
 
   function welcomeMessage (session) {
-      return session.localizer.gettext(session.preferredLocale(), "history-welcome");
+      return session.localizer.gettext(session.preferredLocale(), "welcome", _lib.name);
   }
 
   function initialize (locale) {
 
     // Create LUIS recognizer that points at our model for selected locale
-    model = config.get('LUIS_modelBaseURL')+"?id="+config.get('LUIS_applicationId_' + locale)+"&subscription-key="+config.get('LUIS_subscriptionKey')+"&q=";
+    model = config.get('LUIS_modelBaseURL')+"/"+config.get('LUIS_applicationId_' + locale)+"?subscription-key="+config.get('LUIS_subscriptionKey')+"&q=";
 
     var recognizer = new builder.LuisRecognizer(model);
     intents = new builder.IntentDialog({ recognizers: [recognizer] });
@@ -53,7 +53,10 @@ var feedbackBot = (function () {
     intents.matches('history.info', "historyBot:info");
     intents.matches('history.goback', "historyBot:goback");
     
-    return intents;
+    return {
+      intents: intents,
+      recognizer: recognizer
+    };
   };
 
   return {
@@ -65,4 +68,4 @@ var feedbackBot = (function () {
 
 })();
 
-module.exports = feedbackBot;
+module.exports = historyBot;

--- a/bots/history/locale/en/historyBot.json
+++ b/bots/history/locale/en/historyBot.json
@@ -1,0 +1,6 @@
+{
+  "name": "History",
+  "welcome": "Try 'tell me about history' or 'go back to 2001'",
+  "details": "Let me tell you all about history...",
+  "goback": "Going back in time..."
+}

--- a/bots/history/locale/en/index.json
+++ b/bots/history/locale/en/index.json
@@ -1,6 +1,0 @@
-{
-  "history-name": "History",
-  "history-welcome": "Try 'tell me about history' or 'go back to 2001'",
-  "history-details": "Let me tell you all about history...",
-  "history-goback": "Going back in time..."
-}

--- a/bots/history/locale/es/historyBot.json
+++ b/bots/history/locale/es/historyBot.json
@@ -1,0 +1,6 @@
+{
+  "name": "Historia",
+  "welcome": "Intenta 'Cuéntame algo sobre historia' o 'Vuelve a 2001'",
+  "details": "Yo te hablaré de la historia...",
+  "goback": "Retrocedamos en el tiempo..."
+}

--- a/bots/history/locale/es/index.json
+++ b/bots/history/locale/es/index.json
@@ -1,6 +1,0 @@
-{
-  "history-name": "historia",
-  "history-welcome": "Intenta 'cuéntame sobre la historia' o 'vuelve a 2001'",
-  "history-details": "Yo te hablan de la historia...",
-  "history-goback": "Retroceder en el tiempo..."
-}

--- a/config/dev.sample.json
+++ b/config/dev.sample.json
@@ -1,8 +1,12 @@
 {
-  "BOT_MicrosoftAppId": "",
-  "BOT_MicrosoftAppPassword": "",
-  "LUIS_modelBaseURL":"https://api.projectoxford.ai/luis/v1/application",
+  "MicrosoftAppId": "",
+  "MicrosoftAppPassword": "",
+  "COSMOSDB_host": "https://mycosmosdb.documents.azure.com:443/",
+  "COSMOSDB_key": "67ITy8OF0EfCtSVgAJWxGwghqHhAcwSwCx3VqUSPo2mO75z9o6sRcBJmuBSNFZzp8oTCAslfAFRQpXyv2zdyDA==",
+  "LUIS_modelBaseURL":"https://westeurope.api.cognitive.microsoft.com/luis/v2.0/apps",
   "LUIS_applicationId_en":"a0a68090-8dd2-4dde-96f8-d5d6517cee32",
   "LUIS_applicationId_es":"b793dd65-7bc1-40fe-920d-497063d35497",
-  "LUIS_subscriptionKey":"d7b46a6c72bf46c1b67f2c4f21acf960"
+  "LUIS_subscriptionKey":"d7b46a6c72bf46c1b67f2c4f21acf960",
+  "BotDevAppInsightsKey":"3434be39-3249-4f2f-3b1d-96467f3343ff",
+  "SENTIMENT_subscriptionkey":"52f0a61a4bc24f0f96628a3eb1834a1d"
 }

--- a/config/test.config.json
+++ b/config/test.config.json
@@ -1,6 +1,6 @@
 {
-  "BOT_MicrosoftAppId": "",
-  "BOT_MicrosoftAppPassword": "",
+  "MicrosoftAppId": "",
+  "MicrosoftAppPassword": "",
   "LUIS_modelBaseURL":"https://luis.url",
   "LUIS_applicationId_en":"en",
   "LUIS_applicationId_es":"es",

--- a/languageLibrary.js
+++ b/languageLibrary.js
@@ -12,8 +12,7 @@ var languageLibrary = (function () {
 
     _lib.dialog('change', [
         function (session, args, next) {
-            session.send('Please choose a language \n\n Por favor, elige un idioma');
-            builder.Prompts.choice(session, '', Object.keys(LANGUAGES));
+            builder.Prompts.choice(session, 'Please choose a language \n\n Por favor, elige un idioma', Object.keys(LANGUAGES), { listStyle: builder.ListStyle.button });
         },
         function (session, results, next) {
             session.userData[LOCALE_VAR] = LANGUAGES[results.response.entity];
@@ -21,7 +20,7 @@ var languageLibrary = (function () {
             session.preferredLocale(session.userData[LOCALE_VAR]);
             _bot.settings.localizerSettings.defaultLocale = session.preferredLocale();
 
-            session.send('languageLibrary:language-change-success');
+            session.send('language-change-success');
             session.endDialog();
         }
     ]);

--- a/locale/en/index.json
+++ b/locale/en/index.json
@@ -3,7 +3,5 @@
   "locale-home": "Home message",
   "conversation-end": "The conversation has ended",
   "master-dialog-done": "Dialog is done",
-  "what-to-do": "What bot do you want?",
-
-  "languageLibrary:language-change-success": "Language change was successfull"
+  "what-to-do": "What bot do you want?"
 }

--- a/locale/en/languageLibrary.json
+++ b/locale/en/languageLibrary.json
@@ -1,0 +1,3 @@
+{
+    "language-change-success": "Language change was successfull"
+}

--- a/locale/es/index.json
+++ b/locale/es/index.json
@@ -1,9 +1,7 @@
 {
   "welcome-message": "Bienvenido",
-  "locale-home": "mensaje a casa",
-  "conversation-end": "la conversación ha terminado",
-  "master-dialog-done": "el diálogo ha terminado",
-  "what-to-do": "¿Que te gustaría hacer?",
-
-  "languageLibrary:language-change-success": "cambio de idioma es un éxito"
+  "locale-home": "Mensaje a casa",
+  "conversation-end": "La conversación ha terminado",
+  "master-dialog-done": "El diálogo ha terminado",
+  "what-to-do": "¿Qué te gustaría hacer?"
 }

--- a/locale/es/languageLibrary.json
+++ b/locale/es/languageLibrary.json
@@ -1,0 +1,3 @@
+{
+    "language-change-success": "El cambio de idioma ha sido un éxito"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2102 @@
+{
+  "name": "multilingual-uber-bot",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.0.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
+      }
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "applicationinsights": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-0.20.1.tgz",
+      "integrity": "sha1-+5Z+BRkzDAWT7rWvtaB4g2wkML4=",
+      "requires": {
+        "diagnostic-channel": "0.1.0",
+        "diagnostic-channel-publishers": "0.1.2",
+        "zone.js": "0.7.6"
+      }
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+    },
+    "assert": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+      "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+      "dev": true,
+      "requires": {
+        "util": "0.10.3"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+    },
+    "azure-storage": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-1.4.0.tgz",
+      "integrity": "sha1-+1L6aLPvppgMM/18XNSJt63EbtE=",
+      "requires": {
+        "browserify-mime": "1.2.9",
+        "extend": "1.2.1",
+        "json-edm-parser": "0.1.2",
+        "node-uuid": "1.4.8",
+        "readable-stream": "2.0.6",
+        "request": "2.74.0",
+        "underscore": "1.4.4",
+        "validator": "3.22.2",
+        "xml2js": "0.2.7",
+        "xmlbuilder": "0.4.3"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+        },
+        "async": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+        },
+        "boom": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "caseless": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "extend": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz",
+          "integrity": "sha1-oPX9bPyDpf5J72mNYOyKYk3UV2w="
+        },
+        "form-data": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+          "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
+          "requires": {
+            "async": "2.6.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
+          }
+        },
+        "har-validator": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+          "requires": {
+            "chalk": "1.1.3",
+            "commander": "2.9.0",
+            "is-my-json-valid": "2.17.1",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
+          }
+        },
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+        },
+        "qs": {
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
+          "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4="
+        },
+        "readable-stream": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.74.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+          "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs=",
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "bl": "1.1.2",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "1.0.1",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "node-uuid": "1.4.8",
+            "oauth-sign": "0.8.2",
+            "qs": "6.2.3",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.4.3"
+          },
+          "dependencies": {
+            "extend": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+              "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+            }
+          }
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+        }
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "2.5.3",
+        "regenerator-runtime": "0.11.1"
+      }
+    },
+    "backoff": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
+      "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
+      "requires": {
+        "precond": "0.2.3"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "base64url": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
+      "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "big-integer": {
+      "version": "1.6.26",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.26.tgz",
+      "integrity": "sha1-OvFnL6Ytry1eyvrPblqg0l4Cwcg="
+    },
+    "big-number": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/big-number/-/big-number-0.3.1.tgz",
+      "integrity": "sha1-rHMCDApZu3nrF8LOLbd/d9l04BM="
+    },
+    "binary-search-bounds": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.3.tgz",
+      "integrity": "sha1-X/hhbW3SylOIvIWy1iZuK52lAtw="
+    },
+    "bl": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+      "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
+      "requires": {
+        "readable-stream": "2.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "boom": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "requires": {
+        "hoek": "4.2.0"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+          "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+        }
+      }
+    },
+    "botbuilder": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-3.14.0.tgz",
+      "integrity": "sha512-Hzect51OCaCtdnduBoquZcUpYVK+9lto0KWlUm1rSjsImx7ff/aa/K9wHpsKBmzEENs6/xslgHU2XqPhYg36lw==",
+      "requires": {
+        "async": "1.5.2",
+        "base64url": "2.0.0",
+        "chrono-node": "1.3.5",
+        "jsonwebtoken": "7.4.3",
+        "promise": "7.3.1",
+        "request": "2.83.0",
+        "rsa-pem-from-mod-exp": "0.8.4",
+        "sprintf-js": "1.1.1",
+        "url-join": "1.1.0"
+      }
+    },
+    "botbuilder-azure": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/botbuilder-azure/-/botbuilder-azure-3.0.4.tgz",
+      "integrity": "sha1-YxwVQ+Jp9jQBkQI4h6pPJOHvRT8=",
+      "requires": {
+        "async": "2.6.0",
+        "azure-storage": "1.4.0",
+        "botbuilder": "3.14.0",
+        "documentdb": "1.14.2",
+        "promise": "7.3.1",
+        "tedious": "2.3.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        }
+      }
+    },
+    "botbuilder-instrumentation": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/botbuilder-instrumentation/-/botbuilder-instrumentation-1.1.16.tgz",
+      "integrity": "sha1-M65rh1VZqlNY4KJOglmeyTuMdGk=",
+      "requires": {
+        "applicationinsights": "0.20.1",
+        "botbuilder": "3.7.0",
+        "lodash": "4.17.4",
+        "request": "2.83.0"
+      },
+      "dependencies": {
+        "base64url": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.6.tgz",
+          "integrity": "sha1-1k03XWinxkDZEuI1jRcNylu1RoE=",
+          "requires": {
+            "concat-stream": "1.4.10",
+            "meow": "2.0.0"
+          }
+        },
+        "botbuilder": {
+          "version": "3.7.0",
+          "resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-3.7.0.tgz",
+          "integrity": "sha1-apwMkzbd3PxwNNCOp+hnHK8GDms=",
+          "requires": {
+            "async": "1.5.2",
+            "base64url": "1.0.6",
+            "chrono-node": "1.3.5",
+            "jsonwebtoken": "7.4.3",
+            "promise": "7.3.1",
+            "request": "2.83.0",
+            "rsa-pem-from-mod-exp": "0.8.4",
+            "sprintf-js": "1.1.1",
+            "url-join": "1.1.0"
+          }
+        }
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "browserify-mime": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/browserify-mime/-/browserify-mime-1.2.9.tgz",
+      "integrity": "sha1-rrGvKN5sDXpqLOQK22j/GEIq8x8="
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
+    "bunyan": {
+      "version": "1.8.12",
+      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz",
+      "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
+      "requires": {
+        "dtrace-provider": "0.8.6",
+        "moment": "2.20.1",
+        "mv": "2.1.1",
+        "safe-json-stringify": "1.0.4"
+      }
+    },
+    "camelcase": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+    },
+    "camelcase-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+      "integrity": "sha1-vRoRv5sxoc5JNJOpMN4aC69K1+w=",
+      "requires": {
+        "camelcase": "1.2.1",
+        "map-obj": "1.0.1"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+        }
+      }
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "chai": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.1.0",
+        "deep-eql": "0.1.3",
+        "type-detect": "1.0.0"
+      }
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        }
+      }
+    },
+    "chrono-node": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-1.3.5.tgz",
+      "integrity": "sha1-oklSmKMtqCvMAa2b59d++l4kQSI=",
+      "requires": {
+        "moment": "2.20.1"
+      }
+    },
+    "cliui": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wrap-ansi": "2.1.0"
+      }
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+      "integrity": "sha1-rMO79WAsuMyYDGrIQPp9hgPj7zY=",
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "1.1.14",
+        "typedarray": "0.0.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "core-js": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cryptiles": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "requires": {
+        "boom": "5.2.0"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        },
+        "hoek": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+          "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+        }
+      }
+    },
+    "csv": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/csv/-/csv-0.4.6.tgz",
+      "integrity": "sha1-jbrn3f26rmLB6ph8Pg+Kmsc3tz0=",
+      "requires": {
+        "csv-generate": "0.0.6",
+        "csv-parse": "1.3.3",
+        "csv-stringify": "0.0.8",
+        "stream-transform": "0.1.2"
+      }
+    },
+    "csv-generate": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.6.tgz",
+      "integrity": "sha1-l+TmOuRrIZEs2UdbwxRp0m9a3mY="
+    },
+    "csv-parse": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-1.3.3.tgz",
+      "integrity": "sha1-0c/YdDwvhJoKuy/VRNtWaV0ZpJA="
+    },
+    "csv-stringify": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-0.0.8.tgz",
+      "integrity": "sha1-Usw7PfwZd1jFWtMlqVvoUHH55Rs="
+    },
+    "ctype": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+      "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8="
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "dev": true,
+      "requires": {
+        "type-detect": "0.1.1"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+          "dev": true
+        }
+      }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "detect-node": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz",
+      "integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc="
+    },
+    "diagnostic-channel": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.1.0.tgz",
+      "integrity": "sha1-emrYrVBmusVE2go3m6F0ujYqV88=",
+      "requires": {
+        "semver": "5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+        }
+      }
+    },
+    "diagnostic-channel-publishers": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.1.2.tgz",
+      "integrity": "sha1-M7LDMzkv1+lzMTtO+t+MYAv+ph4="
+    },
+    "diff": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "dev": true
+    },
+    "documentdb": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/documentdb/-/documentdb-1.14.2.tgz",
+      "integrity": "sha512-VTytduwd3Sjk2vNA1GV0ZZ3BOCMtb2Qp+Qu+n3df320mTYtHDY15D6cjR2W/9o3j1eE3S8mLJ+qCTU3uhy2wFw==",
+      "requires": {
+        "big-integer": "1.6.26",
+        "binary-search-bounds": "2.0.3",
+        "int64-buffer": "0.1.10",
+        "priorityqueuejs": "1.0.0",
+        "semaphore": "1.0.5",
+        "tunnel": "0.0.5",
+        "underscore": "1.8.3"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+        }
+      }
+    },
+    "dtrace-provider": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.6.tgz",
+      "integrity": "sha1-QooiOv4DQl0s1tY0f99AxmkDVj0=",
+      "optional": true,
+      "requires": {
+        "nan": "2.8.0"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz",
+      "integrity": "sha1-S8kmJ07Dtau1AW5+HWCSGsJisqE=",
+      "requires": {
+        "base64url": "2.0.0",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "escape-regexp-component": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz",
+      "integrity": "sha1-nGO20LJf8qiMOtvRjFthrMO5+qI="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fast-deep-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.17"
+      }
+    },
+    "formidable": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz",
+      "integrity": "sha1-lriIb3w8NQi5Mta9cMTTqI818ak="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "requires": {
+        "is-property": "1.0.2"
+      }
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "glob": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+      "optional": true,
+      "requires": {
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "handle-thing": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
+      "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "requires": {
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "hawk": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "requires": {
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.0",
+        "sntp": "2.1.0"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+          "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+        }
+      }
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+    },
+    "hpack.js": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+      "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+      "requires": {
+        "inherits": "2.0.3",
+        "obuf": "1.1.1",
+        "readable-stream": "2.3.3",
+        "wbuf": "1.7.2"
+      }
+    },
+    "http-deceiver": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+      "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.13.1"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+    },
+    "indent-string": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+      "integrity": "sha1-25m8xYPrarux5I3LsZmamGBBy2s=",
+      "requires": {
+        "get-stdin": "4.0.1",
+        "minimist": "1.2.0",
+        "repeating": "1.1.3"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
+    "int64-buffer": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.10.tgz",
+      "integrity": "sha1-J3siiofZWtd30HwTgyAiQGpHNCM="
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-my-json-valid": {
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
+      "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isemail": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
+      "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "joi": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
+      "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
+      "requires": {
+        "hoek": "2.16.3",
+        "isemail": "1.2.0",
+        "moment": "2.20.1",
+        "topo": "1.1.0"
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
+    },
+    "json-edm-parser": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/json-edm-parser/-/json-edm-parser-0.1.2.tgz",
+      "integrity": "sha1-HmCw/vG8CvZ7wNFG393lSGzWFbQ=",
+      "requires": {
+        "jsonparse": "1.2.0"
+      }
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
+    "jsonparse": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz",
+      "integrity": "sha1-XAxWhRBxYOcv50ib3eoLRMK8Z70="
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
+    },
+    "jsonwebtoken": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.4.3.tgz",
+      "integrity": "sha1-d/UCHeBYtgWheD+hKD6ZgS5kVjg=",
+      "requires": {
+        "joi": "6.10.1",
+        "jws": "3.1.4",
+        "lodash.once": "4.1.1",
+        "ms": "2.1.1",
+        "xtend": "4.0.1"
+      }
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "jwa": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.5.tgz",
+      "integrity": "sha1-oFUs4CIHQs1S4VN3SjKQXDDnVuU=",
+      "requires": {
+        "base64url": "2.0.0",
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.9",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "jws": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.4.tgz",
+      "integrity": "sha1-+ei5M46KhHJ31kRLFGT2GIDgUKI=",
+      "requires": {
+        "base64url": "2.0.0",
+        "jwa": "1.1.5",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "keep-alive-agent": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz",
+      "integrity": "sha1-RIR8o5TOjWtSGuhYFr1kUJlCs4U="
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "requires": {
+        "invert-kv": "1.0.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
+      }
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
+    "lru-cache": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
+    },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+    },
+    "meow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
+      "integrity": "sha1-j1MKjs9dQNP0tN+Tw0cpAPuiqPE=",
+      "requires": {
+        "camelcase-keys": "1.0.0",
+        "indent-string": "1.2.2",
+        "minimist": "1.2.0",
+        "object-assign": "1.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+    },
+    "mime-db": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+    },
+    "mime-types": {
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "requires": {
+        "mime-db": "1.30.0"
+      }
+    },
+    "minimalistic-assert": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+      "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.8",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "he": "1.1.1",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "moment": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
+      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
+    },
+    "ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+    },
+    "mv": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+      "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
+      "optional": true,
+      "requires": {
+        "mkdirp": "0.5.1",
+        "ncp": "2.0.0",
+        "rimraf": "2.4.5"
+      }
+    },
+    "nan": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+      "optional": true
+    },
+    "nconf": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.8.5.tgz",
+      "integrity": "sha1-8pQeFWGVL6kGu7MjKM+I1MY155Q=",
+      "requires": {
+        "async": "1.5.2",
+        "ini": "1.3.5",
+        "secure-keys": "1.0.0",
+        "yargs": "3.32.0"
+      }
+    },
+    "ncp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
+      "optional": true
+    },
+    "negotiator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+    },
+    "nock": {
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-9.1.6.tgz",
+      "integrity": "sha512-DuKF+1W/FnMO6MXIGgCIWcM95bETjBbmFdR4v7dAj1zH9a9XhOjAa//PuWh98XIXxcZt7wdiv0JlO0AA0e2kqQ==",
+      "dev": true,
+      "requires": {
+        "chai": "3.5.0",
+        "debug": "2.6.9",
+        "deep-equal": "1.0.1",
+        "json-stringify-safe": "5.0.1",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "propagate": "0.4.0",
+        "qs": "6.5.1",
+        "semver": "5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "dev": true
+        }
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
+    "object-assign": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz",
+      "integrity": "sha1-5l3Idm07R7S4MHRlyDEdoDCwcKY="
+    },
+    "obuf": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.1.tgz",
+      "integrity": "sha1-EEEktsYCxnlogaBCVB0220OlJk4="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "requires": {
+        "lcid": "1.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
+    "precond": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+      "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
+    },
+    "priorityqueuejs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/priorityqueuejs/-/priorityqueuejs-1.0.0.tgz",
+      "integrity": "sha1-LuTyPCVgkT4IwHzlzN1t498sWvg="
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "2.0.6"
+      }
+    },
+    "propagate": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.4.0.tgz",
+      "integrity": "sha1-8/zKCm/gZzanulcpZgaWF8EwtIE=",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "qs": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+    },
+    "readable-stream": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+    },
+    "repeating": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+      "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+      "requires": {
+        "is-finite": "1.0.2"
+      }
+    },
+    "request": {
+      "version": "2.83.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "requires": {
+        "aws-sign2": "0.7.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.1",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.17",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.2.1"
+      }
+    },
+    "restify": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/restify/-/restify-4.3.2.tgz",
+      "integrity": "sha512-zPdFHgl2kq8KeQ5bAsya93bEiYzO2nFqroyzI+GyKP8bzufTq2EzFSpaYoCr7CPYVGAOmGFBvwDC2vr+u85KJQ==",
+      "requires": {
+        "assert-plus": "0.1.5",
+        "backoff": "2.5.0",
+        "bunyan": "1.8.12",
+        "csv": "0.4.6",
+        "dtrace-provider": "0.8.6",
+        "escape-regexp-component": "1.0.2",
+        "formidable": "1.1.1",
+        "http-signature": "0.11.0",
+        "keep-alive-agent": "0.0.1",
+        "lru-cache": "4.1.1",
+        "mime": "1.6.0",
+        "negotiator": "0.6.1",
+        "once": "1.4.0",
+        "qs": "6.5.1",
+        "semver": "4.3.6",
+        "spdy": "3.4.7",
+        "tunnel-agent": "0.4.3",
+        "uuid": "3.2.1",
+        "vasync": "1.6.3",
+        "verror": "1.10.0"
+      },
+      "dependencies": {
+        "asn1": {
+          "version": "0.1.11",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+          "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc="
+        },
+        "assert-plus": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+          "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA="
+        },
+        "http-signature": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+          "integrity": "sha1-F5bPZ6ABrVzWhJ3KCZFIXwkIn+Y=",
+          "requires": {
+            "asn1": "0.1.11",
+            "assert-plus": "0.1.5",
+            "ctype": "0.5.3"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+        }
+      }
+    },
+    "rimraf": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+      "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
+      "optional": true,
+      "requires": {
+        "glob": "6.0.4"
+      }
+    },
+    "rsa-pem-from-mod-exp": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.4.tgz",
+      "integrity": "sha1-NipCxtMEBW1JOz8SvOq7LGV2ptQ="
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "safe-json-stringify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.4.tgz",
+      "integrity": "sha1-gaCY9Efku8P/MxKiQ1IbwGDvWRE=",
+      "optional": true
+    },
+    "sax": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.2.tgz",
+      "integrity": "sha1-c1/6o5oc/4/7lZjwIjq9sDqfsuo="
+    },
+    "secure-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
+      "integrity": "sha1-8MgtmKOxOah3aogIBQuCRDEIf8o="
+    },
+    "select-hose": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+      "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
+    },
+    "semaphore": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.0.5.tgz",
+      "integrity": "sha1-tJJXbmavGT25XWXiXsU/Xxl5jWA="
+    },
+    "semver": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+      "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
+    },
+    "sntp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "requires": {
+        "hoek": "4.2.0"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+          "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+        }
+      }
+    },
+    "spdy": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
+      "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
+      "requires": {
+        "debug": "2.6.9",
+        "handle-thing": "1.2.5",
+        "http-deceiver": "1.2.7",
+        "safe-buffer": "5.1.1",
+        "select-hose": "2.0.0",
+        "spdy-transport": "2.0.20"
+      }
+    },
+    "spdy-transport": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.20.tgz",
+      "integrity": "sha1-c15yBUxIayNU/onnAiVgBKOazk0=",
+      "requires": {
+        "debug": "2.6.9",
+        "detect-node": "2.0.3",
+        "hpack.js": "2.1.6",
+        "obuf": "1.1.1",
+        "readable-stream": "2.3.3",
+        "safe-buffer": "5.1.1",
+        "wbuf": "1.7.2"
+      }
+    },
+    "sprintf": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/sprintf/-/sprintf-0.1.5.tgz",
+      "integrity": "sha1-j4PjmpMXwaUCy324BQ5Rxnn27c8="
+    },
+    "sprintf-js": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
+      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
+    },
+    "sshpk": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "stream-transform": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.1.2.tgz",
+      "integrity": "sha1-fY5rTgOsR4F3j4x5UXUBv7B2Kp8="
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "supports-color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+      "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+      "dev": true,
+      "requires": {
+        "has-flag": "1.0.0"
+      }
+    },
+    "tedious": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tedious/-/tedious-2.3.1.tgz",
+      "integrity": "sha512-aJkmYFzoVf0X/M0yNyYETfWfuaYsK/cWqekf/EGnvYoLENVqL1ATdAVLNZdA7TmZLfWxKf70JLr3h9inki+9zQ==",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "big-number": "0.3.1",
+        "bl": "1.2.1",
+        "depd": "1.1.2",
+        "iconv-lite": "0.4.19",
+        "readable-stream": "2.3.3",
+        "sprintf": "0.1.5"
+      },
+      "dependencies": {
+        "bl": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
+          "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+          "requires": {
+            "readable-stream": "2.3.3"
+          }
+        }
+      }
+    },
+    "topo": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
+      "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
+      "requires": {
+        "hoek": "2.16.3"
+      }
+    },
+    "tough-cookie": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
+    "tunnel": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.5.tgz",
+      "integrity": "sha512-gj5sdqherx4VZKMcBA4vewER7zdK25Td+z1npBqpbDys4eJrLx+SlYjJvq1bDXs2irkuJM5pf8ktaEQVipkrbA=="
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
+    },
+    "type-detect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "dev": true
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "underscore": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+      "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
+    },
+    "url-join": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
+      "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg="
+    },
+    "util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.1"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+          "dev": true
+        }
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+    },
+    "validator": {
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-3.22.2.tgz",
+      "integrity": "sha1-byl65n9/gqzHbQr9tJ8Y2aCcGMA="
+    },
+    "vasync": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/vasync/-/vasync-1.6.3.tgz",
+      "integrity": "sha1-SmnXBSpH9M6FUD12Qd8cv0BDKpQ=",
+      "requires": {
+        "verror": "1.6.0"
+      },
+      "dependencies": {
+        "extsprintf": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz",
+          "integrity": "sha1-WtlGwi9bMrp/jNdCZxHG6KP8JSk="
+        },
+        "verror": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
+          "integrity": "sha1-fROyex+swuLakEBetepuW90lLqU=",
+          "requires": {
+            "extsprintf": "1.2.0"
+          }
+        }
+      }
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      }
+    },
+    "wbuf": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.2.tgz",
+      "integrity": "sha1-1pe5nx9ZUS3ydRvkJ2nBWAtYAf4=",
+      "requires": {
+        "minimalistic-assert": "1.0.0"
+      }
+    },
+    "window-size": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xml2js": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.7.tgz",
+      "integrity": "sha1-GDhRi7AXQcrgh4urSRXklMMjBq8=",
+      "requires": {
+        "sax": "0.5.2"
+      }
+    },
+    "xmlbuilder": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.3.tgz",
+      "integrity": "sha1-xGFLp04K0ZbmCcknLNnh3bKKilg="
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "y18n": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+    },
+    "yargs": {
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+      "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+      "requires": {
+        "camelcase": "2.1.1",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "os-locale": "1.4.0",
+        "string-width": "1.0.2",
+        "window-size": "0.1.4",
+        "y18n": "3.2.1"
+      }
+    },
+    "zone.js": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.7.6.tgz",
+      "integrity": "sha1-+7w50+AmHQmG8boGMG6zrrDSIAk="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   "homepage": "https://github.com/morsh/multilingual-uber-bot#readme",
   "dependencies": {
     "botbuilder": "^3.4.4",
+    "botbuilder-azure": "^3.0.4",
+    "botbuilder-instrumentation": "^1.1.16",
     "nconf": "^0.8.4",
     "restify": "^4.3.0"
   },

--- a/test/common.js
+++ b/test/common.js
@@ -2,8 +2,8 @@ var assert = require('assert');
 var nock = require('nock');
 
 function setup() {
-  var englishModel = '/?id=en&subscription-key=subId&q=';
-  var spanishModel = '/?id=es&subscription-key=subId&q=';
+  var englishModel = '/en?subscription-key=subId&q=';
+  var spanishModel = '/es?subscription-key=subId&q=';
   nock('https://luis.url')
     .get(englishModel + encodeURIComponent('go back to 2009'))
     .reply(200, {
@@ -99,5 +99,9 @@ function testBot(bot, messages, done) {
 
 module.exports = {
   setup,
-  testBot
+  testBot,
+  fakeInstrumentation: {
+    monitor: function () {},
+    trackGoalTriggeredEvent: function() {}
+  }
 };

--- a/test/dialog-flows/context-switch.js
+++ b/test/dialog-flows/context-switch.js
@@ -1,26 +1,23 @@
-var history = require('../../bots/history/locale/en');
-var feedback = require('../../bots/feedback/locale/en');
+var history = require('../../bots/history/locale/en/historyBot');
+var feedback = require('../../bots/feedback/locale/en/feedbackBot');
 
 module.exports = [
   {
-      in: "Please choose a language \n\n Por favor, elige un idioma"
-    },
-    {
-      in: " (1. English or 2. Español)",
-      out: "English"
-    },
-    {
-      in: "Language change was successfull",
-    },
-    {
-      in: /^(What bot do you want?).*(2. History)/i,
-      out: "history"
-    },
-    { 
-      in: history["history-welcome"], 
-      out: "go feedback" 
-    },
-    {
-      in: feedback["feedback-welcome"]
-    }
+    in: "Please choose a language \n\n Por favor, elige un idioma",
+    out: "English"
+  },
+  {
+    in: "Language change was successfull",
+  },
+  {
+    in: "What bot do you want?",
+    out: "history"
+  },
+  { 
+    in: history["history-welcome"], 
+    out: "go feedback" 
+  },
+  {
+    in: feedback["feedback-welcome"]
+  }
 ];

--- a/test/dialog-flows/history-intents.js
+++ b/test/dialog-flows/history-intents.js
@@ -1,19 +1,16 @@
-var history = require('../../bots/history/locale/en');
-var feedback = require('../../bots/feedback/locale/en');
+var history = require('../../bots/history/locale/en/historyBot');
+var feedback = require('../../bots/feedback/locale/en/feedbackBot');
 
 module.exports = [
     {
-      in: "Please choose a language \n\n Por favor, elige un idioma"
-    },
-    {
-      in: " (1. English or 2. Español)",
+      in: "Please choose a language \n\n Por favor, elige un idioma",
       out: "English"
     },
     {
       in: "Language change was successfull",
     },
     {
-      in: /^(What bot do you want?).*(2. History)/i,
+      in: "What bot do you want?",
       out: "history"
     },
     { 

--- a/test/index.js
+++ b/test/index.js
@@ -12,9 +12,10 @@ common.setup();
 //Our parent block
 describe('Bot Tests', () => {
 
-  it('should recognize ahistory intents', function (done) { 
+  it('should recognize history intents', function (done) { 
       var connector = new builder.ConsoleConnector();
-      var bot = uberBot.create(connector);
+      var inMemoryStorage = new builder.MemoryBotStorage();
+      var bot = uberBot.create(connector, inMemoryStorage, common.fakeInstrumentation);
 
       common.testBot(bot, historyMessages, done);
       
@@ -23,8 +24,9 @@ describe('Bot Tests', () => {
 
   it('context switching', function (done) { 
       var connector = new builder.ConsoleConnector();
+      var inMemoryStorage = new builder.MemoryBotStorage();
+      var bot = uberBot.create(connector, inMemoryStorage, common.fakeInstrumentation);       
 
-      var bot = uberBot.create(connector);       
       common.testBot(bot, switchingMessages, done);
       
       connector.processMessage('hi');

--- a/uber-bot.js
+++ b/uber-bot.js
@@ -1,152 +1,157 @@
 var fs = require('fs');
 var path = require('path');
-
 var builder = require('botbuilder');
 
 var languageLibrary = require('./languageLibrary')
 
-function create(connector) {
+function create(connector, storage, instrumentation) {
 
-  // Defining the default language as english
-  var bot = new builder.UniversalBot(connector, {
-      localizerSettings: {
-          defaultLocale: "en"
-      }
-  });
+    // Defining the default language as English
+    var bot = new builder.UniversalBot(connector, {
+        localizerSettings: {
+            defaultLocale: "en"
+        }
+    })
+    .set('storage', storage);
 
-  bot.endConversationAction('cancel', 'conversation-end', { matches: /^(cancel|cancelar)/i });
+    // Send bot data to App Insights
+    instrumentation.monitor(bot);
 
-  // Adding language change library to bot 
-  bot.library(languageLibrary.createLibrary(bot));
+    bot.endConversationAction('cancel', 'conversation-end', { matches: /^(cancel|cancelar)/i });
 
-  // Adding middleware to intercept all received messages
-  bot.use({
-      botbuilder: function (session, next) {
+    // Adding language change library to bot 
+    bot.library(languageLibrary.createLibrary(bot));
 
-          var message = session &&
-              session.message &&
-              session.message.text &&
-              session.message.text.toLowerCase() || '';
+    // Adding middleware to intercept all received messages
+    bot.use({
+        botbuilder: function (session, next) {
+            
+            var message = session &&
+                session.message &&
+                session.message.text &&
+                session.message.text.toLowerCase() || '';
 
-          var restartDialog = false;
-          if (message === 'go home') {
-              restartDialog = true;
+            var restartDialog = false;
+            if (message === 'go home') {
+                instrumentation.trackGoalTriggeredEvent('GoHome', {Message: 'User wanted to go home'}, session);
+                restartDialog = true;
 
-          // go <bot name> will redirect to that bot
-          } else {
+            // go <bot name> will redirect to that bot
+            } else {
 
-              // Find the corresponding bot
-              var goBot = bots.find(function (bot) {
-                  return ('go ' + bot.getName(session).toLowerCase() == message);
-              });
+                // Find the corresponding bot
+                var goBot = bots.find(function (bot) {
+                    return ('go ' + bot.getName(session).toLowerCase() == message);
+                });
 
-              if (goBot) {
+                if (goBot) {
 
-                  // This will ensure that the next bot will be the one requested
-                  session.conversationData.nextBot = goBot.getName(session);
-                  restartDialog = true;
-              } else {
-                  next();
-              }
-          }
+                    // This will ensure that the next bot will be the one requested
+                    session.conversationData.nextBot = goBot.getName(session);
+                    restartDialog = true;
+                } else {
+                    next();
+                }
+            }
 
-          if (restartDialog) {
-              if (session.sessionState.callstack && session.sessionState.callstack.length) {
-                  session.cancelDialog(0, '/');
-              } else {
-                  session.beginDialog('/');
-              }
-          }
+            if (restartDialog) {
+                instrumentation.trackGoalTriggeredEvent('DialogRestarted', {Message: 'User changed dialog'}, session);
+                if (session.sessionState.callstack && session.sessionState.callstack.length) {
+                    session.cancelDialog(0, '/');
+                } else {
+                    session.beginDialog('/');
+                }
+            }
+        }
+    });
 
-      }
-  });
+    // Loop through bots in the /bots directory and add them as sub bots
+    function getDirectories(srcpath) {
+        return fs.readdirSync(srcpath).filter(function (file) {
+            return fs.statSync(path.join(srcpath, file)).isDirectory();
+        });
+    }
 
-  // Loop through bots in the /bots directory and add them as sub bots
-  function getDirectories(srcpath) {
-      return fs.readdirSync(srcpath).filter(function (file) {
-          return fs.statSync(path.join(srcpath, file)).isDirectory();
-      });
-  }
+    var bots = [];
+    var botDirectories = getDirectories('./bots');
+    for (var dirIdx in botDirectories) {
 
-  var bots = [];
-  var botDirectories = getDirectories('./bots');
-  for (var dirIdx in botDirectories) {
+        var dirName = botDirectories[dirIdx];
+        var childBot = require('./bots/' + dirName);
+        bots.push(childBot);
+        bot.library(childBot.createLibrary());
+    }
 
-      var dirName = botDirectories[dirIdx];
-      var childBot = require('./bots/' + dirName);
-      bots.push(childBot);
-      bot.library(childBot.createLibrary());
-  }
+    var intents = new builder.IntentDialog();
 
-  var intents = new builder.IntentDialog();
+    bot.dialog('/', intents);
 
-  bot.dialog('/', intents);
+    intents.matches(/^(home|menu)/i, "*:home");
+    intents.matches(/^(change language|language|cambiar idioma|idioma)/i, [languageLibrary.changeLocale]);
 
-  intents.matches(/^(home|menu)/i, "*:home");
-  intents.matches(/^(change language|language|cambiar idioma|idioma)/i, [languageLibrary.changeLocale]);
+    bot.dialog('home', [
+        function (session, results) {
+            session.endDialog("locale-home");
+        }
+    ]);
 
-  bot.dialog('home', [
-      function (session, results) {
-          session.endDialog("locale-home");
-      }
-  ]);
+    intents.onDefault([
 
-  intents.onDefault([
+        // Prompting the user to choose a language if none is selected
+        function (session, args, next) {
+            if (!languageLibrary.isLocaleSet(session)) {
+                languageLibrary.changeLocale(session);
+            }
+            else {
+                languageLibrary.ensureLocale(session);
+                next();
+            }
+        },
 
-      // Prompting the user to choose a language if none is selected
-      function (session, args, next) {
-          if (!languageLibrary.isLocaleSet(session)) {
-              languageLibrary.changeLocale(session);
-          }
-          else {
-              languageLibrary.ensureLocale(session);
-              next();
-          }
-      },
+        // Offering the user a bot to choose from
+        function (session, args, next) {
 
-      // Offering the user a bot to choose from
-      function (session, args, next) {
+            if (!session.conversationData.nextBot) {
+                var botNames = bots.map(function (bot) { return bot.getName(session); });
+                builder.Prompts.choice(session, 'what-to-do', botNames, { listStyle: builder.ListStyle.button });
+            } else {
+                next();
+            }
+        },
 
-          if (!session.conversationData.nextBot) {
-              var botNames = bots.map(function (bot) { return bot.getName(session); });
-              builder.Prompts.choice(session, 'what-to-do', botNames);
-          } else {
-              next();
-          }
-      },
+        // Setting up next bot and directing to dialog
+        function (session, args, next) {
 
-      // Setting up next bot and directing to dialog
-      function (session, args, next) {
+            var requestedBot = session.conversationData.nextBot || args.response.entity;
+            delete session.conversationData.nextBot;
 
-          var requestedBot = session.conversationData.nextBot || args.response.entity;
-          delete session.conversationData.nextBot;
+            var selectedBot = bots.find(function (bot) { return bot.getName(session) == requestedBot; });
+            var locale = session.preferredLocale();
+            var botKey = 'locale-' + locale + '-' + requestedBot;
 
-          var selectedBot = bots.find(function (bot) { return bot.getName(session) == requestedBot; });
-          var locale = session.preferredLocale();
-          var botKey = 'locale-' + locale + '-' + requestedBot;
+            if (!bot.dialog(botKey)) {
+                var result = selectedBot.initialize(locale);
+                instrumentation.monitor(null, result.recognizer);
+                bot.dialog(botKey, result.intents);
+            }
 
-          if (!bot.dialog(botKey)) {
-              var localeIntents = selectedBot.initialize(locale);
-              bot.dialog(botKey, localeIntents);
-          }
+            //welcome message
+            var welcomeMessage = null;
+            if (selectedBot.welcomeMessage) {
+                welcomeMessage = selectedBot.welcomeMessage(session);
+            } else {
+                welcomeMessage = "Welcome to the " + requestedBot + " bot!";
+            }
 
-          //welcome message
-          var welcomeMessage = null;
-          if (selectedBot.welcomeMessage) {
-              welcomeMessage = selectedBot.welcomeMessage(session);
-          } else {
-              welcomeMessage = "Welcome to the " + requestedBot + " bot!";
-          }
+            session.send(welcomeMessage);
+            session.beginDialog(botKey);
+        },
+        function (session, args, next) {
+            session.send('master-dialog-done');
+        }
+    ]);
 
-          session.send(welcomeMessage);
-          session.beginDialog(botKey);
-      },
-      function (session, args, next) {
-          session.send('master-dialog-done');
-      }
-  ]);
-
-  return bot;
+    return bot;
 };
 
 module.exports = { create };


### PR DESCRIPTION
I made a few changes to the base code:
- Added CosmosDB as custom state data storage.
- Added instrumentation with botbuilder-instrumentation package to send all messages, intents, etc., to App Insights and be able to consume it with e.g. the Ibex Dashboard (https://github.com/Azure/ibex-dashboard). I also added a couple of examples on how to send Goal events (an specific type of custom event used in Ibex Dashboard).
- Added a sample Bot Analytics Instrumented Dashboard to be used in Ibex Dashboard.
- Modified the names of some configuration properties so they match the names of the properties generated automatically by Azure Bot Service.
- Fixed localization strings used in the libraries and changed the names of localization files so the strings can be found.
- Fixed some Spanish strings.
- Some other minor changes like adding buttons to some messages.
- Fixed LUIS urls to point to the new version of the API.
- Added a couple of LUIS sample apps that can be imported in LUIS.ai and include the intents we need to try this code.
- Modified the tests to reflect the changes I made to the bot: localization file names, buttons instead of inline options and extra parameters to the bot's create method.